### PR TITLE
SITENAME is already included in resource.data

### DIFF
--- a/jquery.xblock.js
+++ b/jquery.xblock.js
@@ -76,7 +76,11 @@
             }
 
             if (resource.kind === 'url') {
-                resourceURL = resource.data;
+                resourceURL = resource.data; // By default, the resource url contains the SITENAME
+
+                if (!resource.data.match(/^\/\//) && !resource.data.match(/^(http|https):\/\//)) {
+                    resourceURL = this.getLmsBaseURL(options) + resource.data;
+                }
 
                 if (resource.mimetype === 'text/css') {
                     $('head').append('<link href="' + resourceURL + '" rel="stylesheet" />')


### PR DESCRIPTION
This fixes the resource URLs when using external resource urls. (ie ooyala player)
