### PR TITLE
deferred-fix: Fix deferred return value - globaleval returns undefined

### DIFF
--- a/jquery.xblock.js
+++ b/jquery.xblock.js
@@ -93,7 +93,7 @@
                 if (resource.mimetype === 'text/css') {
                     $('head').append('<style type="text/css">' + resource.data + '</style>');
                 } else if (resource.mimetype === 'application/javascript') {
-                    deferred = $.globalEval(resource.data);
+                    $.globalEval(resource.data);
                 } else if (resource.mimetype === 'text/html') {
                     $('head').append(resource.data);
                 } else {


### PR DESCRIPTION
Fix for:

```
TypeError: $this.loadResource(...) is undefined
```

Affects XBlocks loading their JS by sending raw text rather than only loading script URLs - in the latest version of jquery-xblock, the return value of `globalEval()` would be used as a promise and is undefined.
