### PR TITLE
add support to simply load xblock using the same host + sending extra data to student_view

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ $('.courseware-content').xblock({
 
 Note that you need to provide the usage id of the XBlock you want to load, and a valid user session id from the LMS.
 
+If you are using jquery.xblock in the same environment/host than the LMS, you can use the useCurrentHost
+option, which simplify the usage. Example:
+
+```js
+$('.courseware-content').xblock({
+    courseId: 'TestX/TST-BRGT/2015-12',
+    usageId: 'i4x:;_;_TestX;_TST-BRGT;_vertical;_0c4f0ca3c3f54a1b8ad5d9830c1d16b0',
+    useCurrentHost: true,
+});
+```
+
 ### Handling events
 
 When a user clicks on a `/jump_to_id` URL, used in courseware content to create links between courseware sections,
@@ -89,3 +100,7 @@ The test environment uses Karma + Chrome.
    ```
 
 2. The coverage report is in the *coverage* folder. ie: coverage/Chrome\ 33.0.1750\ \(Linux\)/index.html
+
+#### TODO
+
+- Add Test for useCurrentHost.

--- a/jquery.xblock.js
+++ b/jquery.xblock.js
@@ -35,6 +35,8 @@
                                  // (eg: `example.com`, defaults to current domain)
             lmsSubDomain: 'lms', // The subdomain part for the LMS (eg, `lms` for `lms.example.com`)
             lmsSecureURL: false, // Is the LMS on HTTPS?
+            useCurrentHost: false, // set to true to load xblock using the current location.hostname
+            data: {}              // additional data to send to student_view. send as GET parameters
         },
 
         loadResources: function(resources, options, root) {
@@ -186,26 +188,35 @@
         setAjaxCSRFToken: function(csrftoken, options, root) {
             var $this = this;
 
-            $.cookie('csrftoken', csrftoken, $this.getCookieOptions(options));
+            if (!options.useCurrentHost) {
+                $.cookie('csrftoken', csrftoken, $this.getCookieOptions(options));
+            }
             $.ajaxSetup({
                 xhrFields: {
                     withCredentials: true,
                 },
                 beforeSend: function(xhr, settings) {
-                    var queryDomain = $('<a>').prop('href', settings.url).prop('hostname'),
-                        lmsDomain = $this.getLmsDomain(options);
+                    if (!options.useCurrentHost) {
+                        var queryDomain = $('<a>').prop('href', settings.url).prop('hostname'),
+                            lmsDomain = $this.getLmsDomain(options);
 
-                    xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+                        xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
 
-                    if (!$this.csrfSafeMethod(settings.type) && queryDomain === lmsDomain) {
-                        xhr.setRequestHeader("X-CSRFToken", csrftoken);
+                        if (!$this.csrfSafeMethod(settings.type) && queryDomain === lmsDomain) {
+                            xhr.setRequestHeader("X-CSRFToken", csrftoken);
+                        }
                     }
                 }
             });
         },
 
         getLmsDomain: function(options) {
-            return options.lmsSubDomain + '.' + options.baseDomain;
+            if (options.useCurrentHost) {
+                return this.location.hostname + ':' + this.location.port;
+            }
+            else {
+                return options.lmsSubDomain + '.' + options.baseDomain;
+            }
         },
 
         getLmsBaseURL: function(options) {
@@ -236,11 +247,14 @@
                 blockURL = this.getViewUrl('student_view', options);
 
             // Set the LMS session cookie on the shared domain to authenticate on the LMS
-            if (!options.sessionId) {
+            if (!options.sessionId && !options.useCurrentHost) {
                 console.log('Error: You must provide a session id from the LMS (cf options)');
                 return;
             }
-            $.cookie('sessionid', options.sessionId, $this.getCookieOptions(options));
+
+            if (!options.useCurrentHost) {
+                $.cookie('sessionid', options.sessionId, $this.getCookieOptions(options));
+            }
 
             // Avoid failing if the XBlock contains XModules
             window.setup_debug = function(){};
@@ -248,6 +262,7 @@
             $.ajax({
                 url: blockURL,
                 dataType: 'json',
+                data: options.data,
                 xhrFields: {
                     withCredentials: true
                 }


### PR DESCRIPTION
This PR is to:
- Use jquery.xblock in the LMS. So, not having to specify the sessionsId and domain make it easier. We just need to specify {useCurrentHost: true}
- We can also add a data attribute in the options. Those will simply be send as get parameter to the student_view.
