### PR TITLE
Support for XBlock children in the jQuery XBlock runtime

### DIFF
--- a/test/fixtures/answer.js
+++ b/test/fixtures/answer.js
@@ -8,5 +8,5 @@ function AnswerBlock(runtime, element) {
                 checkmark.addClass('checkmark-correct icon-ok fa-check');
             }
         }
-    }
+    };
 }

--- a/test/fixtures/mentoring.js
+++ b/test/fixtures/mentoring.js
@@ -1,5 +1,5 @@
 function MentoringBlock(runtime, element) {
-    var children;
+    var children = runtime.children(element);
 
     function callIfExists(obj, fn) {
         if (typeof obj !== 'undefined' && typeof obj[fn] == 'function') {
@@ -9,23 +9,14 @@ function MentoringBlock(runtime, element) {
         }
     }
 
-    function getChildren(element) {
-        if (!_.isUndefined(children))
-            return children;
-
-        var children_dom = $('.xblock-light-child', element);
-        children = [];
-
-        $.each(children_dom, function(index, child_dom) {
-            var child_type = $(child_dom).attr('data-type'),
-                child = window[child_type];
-            if (typeof child !== 'undefined') {
-                child = child(runtime, child_dom);
-                child.name = $(child_dom).attr('name');
-                children.push(child);
+    function initChildren(options) {
+        options = options || {};
+        for (var i=0; i < children.length; i++) {
+            var child = children[i];
+            if (child.type.substr(0,3) == "pb-") {
+                callIfExists(child, 'init', options);
             }
-        });
-        return children;
+        }
     }
 
     function initXBlock() {
@@ -35,10 +26,7 @@ function MentoringBlock(runtime, element) {
             $.post(handlerUrl);
         });
 
-        var children = getChildren(element);
-        _.each(children, function(child) {
-            callIfExists(child, 'init');
-        });
+        initChildren();
     }
 
     initXBlock();

--- a/test/fixtures/xblock.js
+++ b/test/fixtures/xblock.js
@@ -1,31 +1,33 @@
 var XBLOCK_MENTORING_ANSWER = {
     "csrf_token": "5H7uQag10YyEpX6gGne1o98fz8zwJYh0",
     "html": "\
-<div class=\"xblock xblock-student_view\" data-runtime-class=\"LmsRuntime\" data-init=\"MentoringBlock\" \
-    data-course-id=\"edX/Open_DemoX/edx_demo_course\" data-runtime-version=\"1\" \
-    data-usage-id=\"i4x:;_;_edX;_Open_DemoX;_mentoring;_0074176676df4056af3bc098202211b9\" data-block-type=\"mentoring\">\
-    <div class=\"mentoring\">\
-        <div class=\"missing-dependency warning\" data-missing=\"False\">\
-            You need to complete <a href=\"False\">the previous step</a> before\
-            attempting this step.\
-        </div>\
-        <div class=\"xblock-light-child\" name=\"None_0\" data-type=\"HTMLBlock\">\
-            <div><p>What is your goal?</p></div>\
-        </div>\
-        <div class=\"xblock-light-child\" name=\"goal\" data-type=\"AnswerBlock\">\
-            <div class=\"xblock-answer\" data-completed=\"True\">\
-                <textarea class=\"answer editable\" cols=\"50\" rows=\"10\" name=\"input\" data-min_characters=\"0\">\
-                    dsaa\
-                </textarea>\
-                <span class=\"answer-checkmark icon-2x\"></span>\
-            </div>\
-        </div>\
-    <div class=\"attempts\" data-max_attempts=\"0\" data-num_attempts=\"0\"></div>\
-    <div class=\"submit\">\
-        <input type=\"button\" class=\"input-main\" value=\"Submit\"></input>\
+<div class='xblock xblock-student_view' data-runtime-class='LmsRuntime' data-init='MentoringBlock' data-course-id='TextX/101/2015' data-request-token='e5f73ceede3c11e4a685080027880ca6' data-runtime-version='1' data-usage-id='i4x:;_;_edX;_Open_DemoX;_mentoring;_0074176676df4056af3bc098202211b9' data-block-type='mentoring'>\
+  <div class='mentoring themed-xblock' data-mode='standard' data-step='0'>\
+    <div class='missing-dependency warning' data-missing='False'>\
+      You need to complete <a href='False'>the previous step</a> before attempting this step.\
     </div>\
-    <div class=\"messages\"></div>\
-</div>\
+    <div class='title'><h2>Mentoring Questions</h2></div>\
+    <div class='standard-question-block'>\
+      <div class='xblock xblock-student_view xmodule_display xmodule_HtmlModule' data-runtime-class='LmsRuntime' data-init='XBlockToXModuleShim' data-block-type='html' data-request-token='e5f73ceede3c11e4a685080027880ca6' data-runtime-version='1' data-usage-id='i4x:;_;_TextX;_101;_html;_cdd90d4dfa3d473da8c2ef6ab75dedb0' data-type='HTMLModule' data-course-id='TextX/101/2015'>\
+        <p>Some HTML is here inside an HTML block.</p>\
+      </div>\
+      <div class='xblock xblock-mentoring_view' data-name='answer1' data-runtime-class='LmsRuntime' data-init='AnswerBlock' data-course-id='TextX/101/2015' data-request-token='e5f73ceede3c11e4a685080027880ca6' data-runtime-version='1' data-usage-id='i4x:;_;_TextX;_101;_pb-answer;_7c079582098d40c8a2ecf7922d208e34' data-block-type='pb-answer'>\
+        <div class='xblock-answer' data-completed='True'>\
+          <h3 class='question-title'>Question</h3>\
+          <p>What do you think of jquery-xblock?</p>\
+          <textarea class='answer editable' cols='50' rows='10' name='input' data-min_characters='0'></textarea>\
+          <span class='answer-checkmark fa icon-2x'></span>\
+        </div>\
+      </div>\
+      <div class='grade' data-score='0' data-correct_answer='0' data-incorrect_answer='0' data-partially_correct_answer='0' data-max_attempts='0' data-num_attempts='0'>\
+      </div>\
+      <div class='submit'>\
+        <input type='button' class='input-main' value='Submit' disabled='disabled' style='display: inline-block;'>\
+        <div class='attempts' data-max_attempts='0' data-num_attempts='0'></div>\
+      </div>\
+      <div class='messages'></div>\
+    </div>\
+  </div>\
 </div>",
     "resources": [
         [
@@ -54,20 +56,6 @@ var XBLOCK_MENTORING_ANSWER = {
                 "mimetype": "application/javascript",
                 "placement": "foot"
             }
-        ],
-        [
-            '4',
-            {
-                "kind": "text",
-                "data": "\
-<script type=\"text/template\" id=\"xblock-attempts-template\">\
-    <% if (_.isNumber(max_attempts) && max_attempts > 0) {{ %>\
-    <div> You have used <%= _.min([num_attempts, max_attempts]) %> of <%= max_attempts %> attempts.</div>\
-    <% }} %>\
-</script>",
-                "mimetype": "text/html",
-                "placement": "head"
-            }
         ]
     ]
 };
@@ -75,7 +63,7 @@ var XBLOCK_MENTORING_ANSWER = {
 var XBLOCK_LINKS_ANSWER = {
     'csrf_token': "5H7uQag10YyEpX6gGne1o98fz8zwJYh0",
     'html': "\
-<div class=\"xblock xblock-student_view xmodule_display xmodule_HtmlModule xblock-initialized\" \
+<div class=\"xblock xblock-student_view xmodule_display xmodule_HtmlModule\" \
     data-runtime-class=\"LmsRuntime\" data-init=\"XBlockToXModuleShim\" data-block-type=\"html\" \
     data-runtime-version=\"1\" data-usage-id=\"i4x:;_;_TerraCorp;_T101;_html;_3082f5b3cbd74687846619b66b98ae59\" \
     data-type=\"HTMLModule\" data-course-id=\"edX/Open_DemoX/edx_demo_course\">\

--- a/test/test.jquery-xblock.js
+++ b/test/test.jquery-xblock.js
@@ -146,7 +146,7 @@ describe('jquery-xblock', function() {
             expect($('.courseware-content .mentoring .xblock-answer')).to.have.length(1);
         });
 
-        it('called the xblock mentoring and answer init function', function() {
+        it('called the xblock mentoring and answer init functions', function() {
             expect(
                 $('.courseware-content .mentoring .answer-checkmark').hasClass('checkmark-correct')
             ).to.be.true;
@@ -314,8 +314,8 @@ describe('jquery-xblock', function() {
             }));
         });
 
-        it("has loaded a xblock", function() {
-            expect($('.courseware-content .xblock')).to.have.length(1);
+        it("has loaded the xblocks", function() {
+            expect($('.courseware-content .xblock')).to.have.length(3);
         });
 
     });
@@ -333,7 +333,7 @@ describe('jquery-xblock', function() {
             $('.courseware-content').empty();
         });
 
-        it("has loaded the first xblock with options", function() {
+        it("has loaded the xblocks with options", function() {
 
             expect($.xblock.global_options).to.be.null;
 
@@ -343,10 +343,10 @@ describe('jquery-xblock', function() {
             $('.courseware-content').xblock(current_options);
 
             compare_options($.xblock.global_options, current_options);
-            expect($('.courseware-content .xblock')).to.have.length(1);
+            expect($('.courseware-content .xblock')).to.have.length(3);
         });
 
-        it("has loaded the second xblock without options", function() {
+        it("has loaded the xblocks without options", function() {
 
             expect($.xblock.global_options).to.be.a('object');
 
@@ -362,7 +362,7 @@ describe('jquery-xblock', function() {
             }));
 
             $.xblock.watchLinks.restore();
-            expect($('.courseware-content .xblock')).to.have.length(1);
+            expect($('.courseware-content .xblock')).to.have.length(3);
         });
 
     });


### PR DESCRIPTION
This allows jquery-xblock to support XBlocks whose children use JavaScript. It is required for the Problem Builder (mentoring v2) block.